### PR TITLE
fix: replace hardcoded utc timezone with browser timezone

### DIFF
--- a/dashboards/argo-cd-applications.libsonnet
+++ b/dashboards/argo-cd-applications.libsonnet
@@ -717,7 +717,7 @@ local tbOverride = tbStandardOptions.override;
       dashboard.withDescription('A dashboard that monitors ArgoCD with a focus on Application status. It is created using the [argo-cd-mixin](https://github.com/adinhodovic/argo-cd-mixin). Requires custom configuration to add application badges. Please refer to the mixin.') +
       dashboard.withUid($._config.applicationOverviewDashboardUid) +
       dashboard.withTags($._config.tags) +
-      dashboard.withTimezone('utc') +
+      dashboard.withTimezone('browser') +
       dashboard.withEditable(true) +
       dashboard.time.withFrom('now-6h') +
       dashboard.time.withTo('now') +

--- a/dashboards/argo-cd-notifications.libsonnet
+++ b/dashboards/argo-cd-notifications.libsonnet
@@ -190,7 +190,7 @@ local tsLegend = tsOptions.legend;
       dashboard.withDescription('A dashboard that monitors ArgoCD notifications. It is created using the [argo-cd-mixin](https://github.com/adinhodovic/argo-cd-mixin).') +
       dashboard.withUid($._config.notificationsOverviewDashboardUid) +
       dashboard.withTags($._config.tags) +
-      dashboard.withTimezone('utc') +
+      dashboard.withTimezone('browser') +
       dashboard.withEditable(true) +
       dashboard.time.withFrom('now-2d') +
       dashboard.time.withTo('now') +

--- a/dashboards/argo-cd-operational.libsonnet
+++ b/dashboards/argo-cd-operational.libsonnet
@@ -856,7 +856,7 @@ local hmQueryOptions = heatmapPanel.queryOptions;
       dashboard.withDescription('A dashboard that monitors ArgoCD with a focus on the operational. It is created using the [argo-cd-mixin](https://github.com/adinhodovic/argo-cd-mixin).') +
       dashboard.withUid($._config.operationalOverviewDashboardUid) +
       dashboard.withTags($._config.tags) +
-      dashboard.withTimezone('utc') +
+      dashboard.withTimezone('browser') +
       dashboard.withEditable(true) +
       dashboard.time.withFrom('now-6h') +
       dashboard.time.withTo('now') +

--- a/dashboards_out/argo-cd-application-overview.json
+++ b/dashboards_out/argo-cd-application-overview.json
@@ -938,7 +938,7 @@
       "from": "now-6h",
       "to": "now"
    },
-   "timezone": "utc",
+   "timezone": "browser",
    "title": "ArgoCD / Application / Overview",
    "uid": "argo-cd-application-overview-kask"
 }

--- a/dashboards_out/argo-cd-notifications-overview.json
+++ b/dashboards_out/argo-cd-notifications-overview.json
@@ -210,7 +210,7 @@
       "from": "now-2d",
       "to": "now"
    },
-   "timezone": "utc",
+   "timezone": "browser",
    "title": "ArgoCD / Notifications / Overview",
    "uid": "argo-cd-notifications-overview-kask"
 }

--- a/dashboards_out/argo-cd-operational-overview.json
+++ b/dashboards_out/argo-cd-operational-overview.json
@@ -1157,7 +1157,7 @@
       "from": "now-6h",
       "to": "now"
    },
-   "timezone": "utc",
+   "timezone": "browser",
    "title": "ArgoCD / Operational / Overview",
    "uid": "argo-cd-operational-overview-kask"
 }


### PR DESCRIPTION
Hi

I want to use your ArgoCD Grafana dashboards, but unfortunately the timezone `utc` is hardcoded in the dashboards.
I want to deploy your ArgoCD Grafana dashboard directly via `GrafanaDashboard` (Grafana-Operator), but I can't override the timezone. 

Here an example of such a `GrafanaDashboard`:  
```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard 
metadata:
  name: argocd-operational-overview
  labels:
    app: grafana
spec:
  instanceSelector:
    matchLabels:
      grafanaInstance: main
  allowCrossNamespaceImport: true
  datasources:
    - datasourceName: prometheus
      inputName: DS_PROMETHEUS
  contentCacheDuration: 1h
  folder: "ArgoCD"
  grafanaCom:
    id: 19993
    revision: 4
```

To fix this, I created this pull request to change the hardcoded timezone to the dynamic browser timezone.

PS: Thanks for your really nice work! 🚀